### PR TITLE
Changing endpoint for PUT request that changes the response for GET request.

### DIFF
--- a/app/routes/inventory_devices.py
+++ b/app/routes/inventory_devices.py
@@ -46,7 +46,7 @@ def get_guids():
             default_guid_add_response['status_code'])
 
 
-@inventory_devices_bp.route(GUID_ADD_URL, methods=['PUT'])
+@inventory_devices_bp.route(GUID_GET_URL, methods=['PUT'])
 def update_guid_add():
     data = request.get_json()
     default_guid_add_response['body'] = data['body']


### PR DESCRIPTION
When trying to sent a PUT request to GUID_ADD_URL = '/<path:guid>/add', as is says in the code, the response from the server was 500. As I looked into it I understood that GUID_ADD_URL expects a value passes in update_guid_add() to take it from the URL. No value is passed as in method post_guid_add(guid) where the endpoint is "/<path:guid>/add". I changed the endpoint and now the server send a request body and status code 200.
![image](https://github.com/user-attachments/assets/58e05842-07a7-45a1-9b5e-ba0ba1afef4a)
I just suppose that the API is supposed to work like this for PUT request to this endpoint, but I wanted to ask so I know how to proceed and I couldn't find you in Discord.
Thank you in advance!
